### PR TITLE
Limit the identifier names to 63 characters.

### DIFF
--- a/lib/dm-postgres-adapter/adapter.rb
+++ b/lib/dm-postgres-adapter/adapter.rb
@@ -7,6 +7,8 @@ module DataMapper
     class PostgresAdapter < DataObjectsAdapter
 
       module SQL #:nodoc:
+        IDENTIFIER_MAX_LENGTH = 63
+
         private
 
         # @api private


### PR DESCRIPTION
PostgreSQL comes with a compile-time default maximum length of 63 characters for identifier names.  If we take the DataObjects default of 128 characters, then PostgreSQL will 'helpfully' and silently truncate our identifier name (say, the name of a constraint) upon creation.  This has an unfortunate effect of making any subsequent call to manipulate the object identified by more than 63 characters fail, since the object by the longer name does not exist.  So, limit this to 63 characters.
